### PR TITLE
fix invalid HTML output

### DIFF
--- a/src/Resources/contao/classes/InitializeProSearch.php
+++ b/src/Resources/contao/classes/InitializeProSearch.php
@@ -5,7 +5,7 @@ namespace ProSearch;
 class InitializeProSearch {
 
 
-    private $strPlaceholder = '<!-- ### %PROSEARCH_SCRIPT_TAG% ### ->';
+    private $strPlaceholder = '<!-- ### %PROSEARCH_SCRIPT_TAG% ### -->';
 
 
     public function setScriptPlaceholder() {


### PR DESCRIPTION
The missing dash causes invalid HTML output and effectively disables any JavaScript after it.